### PR TITLE
Update python stubs for better editor hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,14 @@ cmake_build/*
 pytheia.egg-info
 pytheia_build/*
 dist/*
+
+src/pytheia/pytheia/
+
+src/pytheia/pytheia/math
+src/pytheia/pytheia/*.pyi
+src/pytheia/pytheia/*/*.pyi
+src/pytheia/__init__.pyi
+src/pytheia/**/*.pyi
+
+# Generated stub directories
+typings/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include src/pytheia/py.typed
+recursive-include src/pytheia *.pyi

--- a/README.md
+++ b/README.md
@@ -296,3 +296,23 @@ Open a second terminal and run
 docker ps # this will give you a list of running containers to find the correct CONTAINER_ID
 docker cp CONTAINER_ID:/home/wheelhouse /path/to/result/folder/pytheia_wheels
 ```
+
+## Typing and editor stubs
+To get full function/argument lists and IntelliSense in editors for the native extension:
+
+- Generate stubs locally (requires `pybind11-stubgen`):
+   
+   ```bash
+   pip install pybind11-stubgen
+   dev/generate_stubs.sh
+   ```
+   
+   This writes `.pyi` files to `typings/pytheia`. VS Code/Pylance will pick them up via `pyrightconfig.json`.
+ 
+ - When building wheels via `setup.py`, stubs are generated automatically by default. To skip:
+   
+   ```bash
+   GENERATE_STUBS=0 python setup.py bdist_wheel --plat-name=...
+   ```
+ 
+ - The package ships a PEP 561 marker (`py.typed`) so downstream type checkers can consume the bundled stubs.

--- a/build_and_install.sh
+++ b/build_and_install.sh
@@ -1,7 +1,6 @@
 rm src/pytheia/*.so
 rm cmake_build
 rm dist/
-# remove egg
 
 BUILD_MARCH_NATIVE=0 python setup.py bdist_wheel --plat-name=manylinux_2_35_x86_64
 cd dist && pip install --force-reinstall *.whl 

--- a/dev/generate_stubs.sh
+++ b/dev/generate_stubs.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: dev/generate_stubs.sh [DEST_DIR]
+# Default destination is ./typings (recommended for editor consumption).
+DEST_DIR="${1:-typings}"
+mkdir -p "${DEST_DIR}"
+
+# Pick a Python interpreter
+if command -v python >/dev/null 2>&1; then
+	PY=python
+elif command -v python3 >/dev/null 2>&1; then
+	PY=python3
+else
+	echo "No python interpreter found (python/python3)." >&2
+	exit 1
+fi
+
+if ! "$PY" -c "import pybind11_stubgen" >/dev/null 2>&1; then
+	echo "pybind11-stubgen not found. Install it via: $PY -m pip install pybind11-stubgen" >&2
+	exit 1
+fi
+
+# Ensure the built extension in src/ is importable
+export PYTHONPATH="$(pwd)/src:${PYTHONPATH:-}"
+
+TMP_DIR="${DEST_DIR}/.gen"
+rm -rf "${TMP_DIR}"
+mkdir -p "${TMP_DIR}"
+
+echo "Generating stubs for 'pytheia' into temporary dir '${TMP_DIR}'..."
+"$PY" -m pybind11_stubgen pytheia -o "${TMP_DIR}"
+
+# pybind11-stubgen typically outputs into <out>/pytheia-stubs/pytheia
+if [ -d "${TMP_DIR}/pytheia-stubs/pytheia" ]; then
+	mkdir -p "${DEST_DIR}/pytheia"
+	rsync -a --delete "${TMP_DIR}/pytheia-stubs/pytheia/" "${DEST_DIR}/pytheia/" || cp -r "${TMP_DIR}/pytheia-stubs/pytheia/." "${DEST_DIR}/pytheia/"
+else
+	# Fallback: copy any .pyi files under TMP_DIR
+	find "${TMP_DIR}" -name '*.pyi' -exec bash -c '
+		for f; do
+			rel="${f#${TMP_DIR}/}"
+			dir="${DEST_DIR}/$(dirname "$rel")"
+			mkdir -p "$dir"
+			cp "$f" "$dir/"
+		done
+	' bash {} +
+fi
+
+# Create PEP 561 marker in stub folder for editors
+: > "${DEST_DIR}/pytheia/py.typed"
+
+rm -rf "${TMP_DIR}"
+echo "Stubs ready in '${DEST_DIR}/pytheia'. Ensure your editor uses this path."

--- a/setup.py
+++ b/setup.py
@@ -64,9 +64,48 @@ def create_package():
     files = glob('cmake_build/lib/pytheia*')
     subprocess.run(['cp'] + files + ['src/pytheia'])
 
+def generate_stubs():
+    """Generate .pyi stubs using pybind11-stubgen if available.
+
+    Controlled via env var GENERATE_STUBS (default on). Skips gracefully if
+    the tool is not available or generation fails.
+    """
+    generate = os.environ.get('GENERATE_STUBS', '1') != '0'
+    if not generate:
+        print('Skipping stub generation (GENERATE_STUBS=0).')
+        return
+    try:
+        env = os.environ.copy()
+        env['PYTHONPATH'] = os.path.abspath('src') + os.pathsep + env.get('PYTHONPATH', '')
+        cmd = [sys.executable, '-m', 'pybind11_stubgen', 'pytheia', '-o', 'src']
+        print('Generating .pyi stubs:', ' '.join(cmd))
+        subprocess.check_call(cmd, env=env)
+        # Move stubs into src/pytheia regardless of output layout
+        import shutil
+        out_variants = [
+            os.path.join('src', 'pytheia'),
+            os.path.join('src', 'pytheia-stubs'),
+        ]
+        target_dir = os.path.join('src', 'pytheia')
+        os.makedirs(target_dir, exist_ok=True)
+        for out_dir in out_variants:
+            if os.path.isdir(out_dir):
+                # Copy over .pyi files (and submodule .pyi) but do not overwrite .py/.so
+                for root, dirs, files in os.walk(out_dir):
+                    rel_root = os.path.relpath(root, out_dir)
+                    dest_root = os.path.join(target_dir, rel_root) if rel_root != '.' else target_dir
+                    os.makedirs(dest_root, exist_ok=True)
+                    for fname in files:
+                        if fname.endswith('.pyi'):
+                            shutil.copy2(os.path.join(root, fname), os.path.join(dest_root, fname))
+        print('Stub files copied into src/pytheia')
+    except Exception as e:
+        print('Stub generation skipped (tool missing or failed):', e)
+
 configure_c_extension()
 build_c_extension()
 create_package()
+generate_stubs()
 
 setuptools.setup(
     name='pytheia',
@@ -86,17 +125,15 @@ setuptools.setup(
     package_dir={
         'pytheia': 'src/pytheia',
     },
-    package_data={
-        'pytheia': [
-            'pytheia.*',
-            'libflann_cpp.*',
-            #'stubs/pytheia/pytheia/__init__.pyi',
-            #'stubs/pytheia/pytheia/io/__init__.pyi',
-            #'stubs/pytheia/pytheia/matching/__init__.pyi',
-            #'stubs/pytheia/pytheia/math/__init__.pyi',
-            #'stubs/pytheia/pytheia/sfm/__init__.pyi',
-            #'stubs/pytheia/pytheia/solvers/__init__.pyi',
-        ]
-    },
+        package_data={
+         'pytheia': [
+             'pytheia.*',
+             'libflann_cpp.*',
+            '*.pyi',
+            '*/*.pyi',
+            '*/*/*.pyi',
+            'py.typed',
+         ]
+     },
     cmdclass={'bdist_wheel': platform_bdist_wheel},
 )

--- a/src/pytheia/__init__.py
+++ b/src/pytheia/__init__.py
@@ -1,2 +1,5 @@
+# This package provides runtime modules and distributes type information via .pyi stubs.
+# PEP 561 marker is provided by the presence of a 'py.typed' file in this package.
+
 from pytheia.pytheia import (io, math, matching, mvs, sfm, solvers)
 import pytheia.pytheia as pytheia

--- a/src/pytheia/py.typed
+++ b/src/pytheia/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. Presence indicates this package ships type information.

--- a/typings/.gitkeep
+++ b/typings/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder to ensure the 'typings' directory exists in VCS.


### PR DESCRIPTION
Integrate automatic Python stub generation and packaging to enable editor IntelliSense for the native extension.

Python native extensions, like those built with Pybind11, do not inherently provide type information for static analysis tools and editors. This PR addresses this by automating the generation and inclusion of `.pyi` stub files, enabling full IntelliSense and type checking for the `pytheia` package.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc442cb3-a81e-48e2-b389-5ab8e53825e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fc442cb3-a81e-48e2-b389-5ab8e53825e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

